### PR TITLE
Do not assume options.uri exists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ var RequestMiddlewareFramework = function(request) {
   this.request = request;
 
   this.initialMiddleware = function(options, callback) {
-    request(options.uri, options, callback);
+    request(options, callback);
   };
 
   this.middleware = [ ];


### PR DESCRIPTION
Rather than call the initial request with `request(options.uri, options, ...)`, we can just call `request(options, ...)`.  options.uri is not required (request.url is a synonym, for example).
